### PR TITLE
Fix signatures not initializing

### DIFF
--- a/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
+++ b/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
@@ -63,6 +63,8 @@ namespace WondrousTailsSolver
         {
             pluginInterface.Create<Service>();
 
+            SignatureHelper.Initialise(this);
+
             var addonUpdatePtr = Service.SigScanner.ScanText("40 53 48 83 EC 30 F6 81 ?? ?? ?? ?? ?? 48 8B D9 0F 29 74 24 ?? 0F 28 F1 0F 84 ?? ?? ?? ?? 80 B9 ?? ?? ?? ?? ?? 48 89 6C 24 ??");
             this.addonUpdateHook = Hook<AddonUpdateDelegate>.FromAddress(addonUpdatePtr, this.AddonUpdateDetour);
             this.addonUpdateHook.Enable();


### PR DESCRIPTION
A recent Dalamud Fix caused a regression
https://github.com/goatcorp/Dalamud/pull/1017

You are now required to `SignatureHelper.Initialize(this);` in main plugin classes if you use signature helper.