### PR TITLE
Fix/Improve TaskLookup

### DIFF
--- a/WondrousTailsSolver/TaskLookup.cs
+++ b/WondrousTailsSolver/TaskLookup.cs
@@ -29,6 +29,7 @@ public static class TaskLookup
             case 0:
                 return Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
                     .Where(c => c.Content == bingoOrderData.Data)
+                    .OrderBy(c => c.SortKey)
                     .Select(c => c.TerritoryType.Row)
                     .ToList();
 
@@ -37,6 +38,7 @@ public static class TaskLookup
                 return Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
                     .Where(m => m.ContentType.Row is 2)
                     .Where(m => m.ClassJobLevelRequired == bingoOrderData.Data)
+                    .OrderBy(c => c.SortKey)
                     .Select(m => m.TerritoryType.Row)
                     .ToList();
 
@@ -72,6 +74,7 @@ public static class TaskLookup
                     // Deep Dungeons
                     3 => Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
                         .Where(m => m.ContentType.Row is 21)
+                        .OrderBy(c => c.SortKey)
                         .Select(m => m.TerritoryType.Row)
                         .ToList(),
 
@@ -80,6 +83,8 @@ public static class TaskLookup
 
             // Multi-instance raids
             case 4:
+                var raidIndex = (int)(bingoOrderData.Data - 11) * 2;
+
                 return bingoOrderData.Data switch
                 {
                     // Binding Coil, Second Coil, Final Coil
@@ -104,7 +109,7 @@ public static class TaskLookup
                         .Where(row => row.ItemLevelRequired >= 425)
                         .OrderBy(row => row.SortKey)
                         .Select(row => row.TerritoryType.Row)
-                        .ToArray()[(int)(-11 + bingoOrderData.Data)..(int)(-10 + bingoOrderData.Data)]
+                        .ToArray()[raidIndex..(raidIndex + 2)]
                         .ToList(),
 
                     _ => new List<uint>(),

--- a/WondrousTailsSolver/TaskLookup.cs
+++ b/WondrousTailsSolver/TaskLookup.cs
@@ -1,183 +1,117 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+
+using Dalamud;
 using Dalamud.Logging;
+using Dalamud.Utility;
 using Lumina.Excel.GeneratedSheets;
 
 namespace WondrousTailsSolver;
 
-internal static class TaskLookup
+/// <summary>
+/// Helper class for converting Task ID's into Zone Lists
+/// </summary>
+public static class TaskLookup
 {
+    /// <summary>
+    /// Processes Wondrous Tails TaskID into a list of zones
+    /// </summary>
+    /// <param name="id">Wondrous Tails TaskID.</param>
+    /// <returns>List of TerritoryType row Id's.</returns>
     public static List<uint> GetInstanceListFromID(uint id)
     {
-        var values = TryGetFromDatabase(id);
+        var bingoOrderData = Service.DataManager.GetExcelSheet<WeeklyBingoOrderData>()!.GetRow(id);
+        if (bingoOrderData is null) return new List<uint>();
 
-        if (values != null)
+        switch (bingoOrderData.Type)
         {
-            return new List<uint> {values.Value};
-        }
+            // Specific Duty
+            case 0:
+                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
+                    .Where(c => c.Content == bingoOrderData.Data)
+                    .Select(c => c.TerritoryType.Row)
+                    .ToList();
 
-        switch (id)
-        {
-            // Dungeons Lv 1-49
+            // Specific Level Dungeon
             case 1:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is >= 1 and <= 49)
-                    .Select(m => m.TerritoryType.Value!.RowId)
+                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
+                    .Where(m => m.ContentType.Row is 2)
+                    .Where(m => m.ClassJobLevelRequired == bingoOrderData.Data)
+                    .Select(m => m.TerritoryType.Row)
                     .ToList();
 
-            // Dungeons Lv 50
+            // Level Range Dungeon
             case 2:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is 50)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
+                return bingoOrderData.Data switch
+                {
+                    // Level 1 - 50
+                    50 => Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
+                        .Where(m => m.ContentType.Row is 2)
+                        .Where(m => m.ClassJobLevelRequired is >= 1 and <= 49)
+                        .Select(m => m.TerritoryType.Row)
+                        .ToList(),
 
-            // Dungeons Lv 51-59
+                    // Level (x - 9) - (x - 1) :: Example => 60 becomes 51 - 59
+                    _ => Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
+                        .Where(m => m.ContentType.Row is 2)
+                        .Where(m => m.ClassJobLevelRequired >= bingoOrderData.Data - 9 && m.ClassJobLevelRequired <= bingoOrderData.Data - 1)
+                        .Select(m => m.TerritoryType.Row)
+                        .ToList(),
+                };
+
+            // Special categories
             case 3:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is >= 51 and <= 59)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
+                return bingoOrderData.Unknown5 switch
+                {
+                    // Treasure Map Instances are Not Supported
+                    1 => new List<uint>(),
 
-            // Dungeons Lv 60
+                    // PvP Categories are Not Supported
+                    2 => new List<uint>(),
+
+                    // Deep Dungeons
+                    3 => Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
+                        .Where(m => m.ContentType.Row is 21)
+                        .Select(m => m.TerritoryType.Row)
+                        .ToList(),
+
+                    _ => new List<uint>(),
+                };
+
+            // Multi-instance raids
             case 4:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is 60)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
+                return bingoOrderData.Data switch
+                {
+                    // Binding Coil, Second Coil, Final Coil
+                    2 => new List<uint> { 241, 242, 243, 244, 245 },
+                    3 => new List<uint> { 355, 356, 357, 358 },
+                    4 => new List<uint> { 193, 194, 195, 196 },
 
-            // Dungeons Lv 61-69
-            case 59:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is >= 61 and <= 69)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
+                    // Gordias, Midas, The Creator
+                    5 => new List<uint> { 442, 443, 444, 445 },
+                    6 => new List<uint> {520, 521, 522, 523},
+                    7 => new List<uint> { 580, 581, 582, 583 },
 
-            // Dungeons Lv 70
-            case 60:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is 70)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
+                    // Deltascape, Sigmascape, Alphascape
+                    8 => new List<uint> { 691, 692, 693, 694 },
+                    9 => new List<uint> { 748, 749, 750, 751 },
+                    10 => new List<uint> { 798, 799, 800, 801 },
 
-            // Dungeons Lv 71-79
-            case 85:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is >= 71 and <= 79)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
+                    > 10 => Service.DataManager.GetExcelSheet<ContentFinderCondition>(ClientLanguage.English)!
+                        .Where(row => row.ContentType.Row is 5)
+                        .Where(row => row.ContentMemberType.Row is 3)
+                        .Where(row => !row.Name.ToDalamudString().TextValue.Contains("Savage"))
+                        .Where(row => row.ItemLevelRequired >= 425)
+                        .OrderBy(row => row.SortKey)
+                        .Select(row => row.TerritoryType.Row)
+                        .ToArray()[(int)(-11 + bingoOrderData.Data)..(int)(-10 + bingoOrderData.Data)]
+                        .ToList(),
 
-            // Dungeons Lv 80
-            case 86:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is 80)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
-
-            // Dungeons lv 81-89
-            case 108:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is >= 81 and <= 89)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
-
-            // Dungeons Lv 90
-            case 109:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId == 2)
-                    .Where(m => m.ClassJobLevelRequired is 90)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
-
-            // Palace of the Dead / Heaven on High
-            case 53:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId is 21)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
-
-            // Treasure Maps
-            case 46:
-                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-                    !.Where(m => m.ContentType.Value?.RowId is 9)
-                    .Select(m => m.TerritoryType.Value!.RowId)
-                    .ToList();
-
-            // The Binding Coil of Bahamut
-            case 121:
-                return new List<uint> { 241, 242, 243, 244, 245 };
-
-            // The Second Coil of Bahamut
-            case 122:
-                return new List<uint> { 355, 356, 357, 358 };
-
-            // The Final Coil of Bahamut
-            case 123:
-                return new List<uint> { 193, 194, 195, 196 };
-
-            // Alexander: Gordias
-            case 124:
-                return new List<uint> { 442, 443, 444, 445 };
-
-            // Alexander: Midas
-            case 125:
-                return new List<uint> {520, 521, 522, 523};
-
-            // Alexander: The Creator
-            case 126:
-                return new List<uint> { 580, 581, 582, 583 };
-
-            // Omega: Deltascape
-            case 127:
-                return new List<uint> { 691, 692, 693, 694 };
-
-            // Omega: Sigmascape
-            case 128:
-                return new List<uint> { 748, 749, 750, 751 };
-
-            // Omega: Alphascape
-            case 129:
-                return new List<uint> { 798, 799, 800, 801 };
-
-            // PvP
-            case 67 or 54 or 52:
-                return new List<uint>();
-
+                    _ => new List<uint>(),
+                };
         }
 
-        if (id != 0)
-        {
-            PluginLog.Information($"[WondrousTails] Unrecognized ID: {id}");
-        }
-
+        PluginLog.Information($"[WondrousTails] Unrecognized ID: {id}");
         return new List<uint>();
-    }
-
-    private static uint? TryGetFromDatabase(uint id)
-    {
-        var instanceContentData = Service.DataManager.GetExcelSheet<WeeklyBingoOrderData>()
-            !.GetRow(id)
-            !.Data;
-
-        if (instanceContentData < 20000)
-        {
-            return null;
-        }
-
-        var data = Service.DataManager.GetExcelSheet<ContentFinderCondition>()
-            !.Where(c => c.Content == instanceContentData)
-            .Select(c => c.TerritoryType.Value!.RowId)
-            .FirstOrDefault();
-
-        return data;
     }
 }

--- a/WondrousTailsSolver/TaskLookup.cs
+++ b/WondrousTailsSolver/TaskLookup.cs
@@ -44,22 +44,12 @@ public static class TaskLookup
 
             // Level Range Dungeon
             case 2:
-                return bingoOrderData.Data switch
-                {
-                    // Level 1 - 50
-                    50 => Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
-                        .Where(m => m.ContentType.Row is 2)
-                        .Where(m => m.ClassJobLevelRequired is >= 1 and <= 49)
-                        .Select(m => m.TerritoryType.Row)
-                        .ToList(),
-
-                    // Level (x - 9) - (x - 1) :: Example => 60 becomes 51 - 59
-                    _ => Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
-                        .Where(m => m.ContentType.Row is 2)
-                        .Where(m => m.ClassJobLevelRequired >= bingoOrderData.Data - 9 && m.ClassJobLevelRequired <= bingoOrderData.Data - 1)
-                        .Select(m => m.TerritoryType.Row)
-                        .ToList(),
-                };
+                return Service.DataManager.GetExcelSheet<ContentFinderCondition>()!
+                    .Where(m => m.ContentType.Row is 2)
+                    .Where(m => m.ClassJobLevelRequired >= bingoOrderData.Data - (bingoOrderData.Data > 50 ? 9 : 49) && m.ClassJobLevelRequired <= bingoOrderData.Data - 1)
+                    .OrderBy(c => c.SortKey)
+                    .Select(m => m.TerritoryType.Row)
+                    .ToList();
 
             // Special categories
             case 3:

--- a/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
+++ b/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
@@ -43,12 +43,6 @@ namespace WondrousTailsSolver
         [Signature("88 05 ?? ?? ?? ?? 8B 43 18", ScanType = ScanType.StaticAddress)]
         private readonly WondrousTails* wondrousTailsData = null!;
 
-        [Signature("48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 41 0F B6 E8")]
-        private readonly delegate* unmanaged<AgentInterface*, uint, byte, IntPtr> openRegularDuty = null!;
-
-        [Signature("E9 ?? ?? ?? ?? 8B 93 ?? ?? ?? ?? 48 83 C4 20")]
-        private readonly delegate* unmanaged<AgentInterface*, byte, byte, IntPtr> openRouletteDuty = null!;
-
         private readonly Hook<AddonUpdateDelegate> addonUpdateHook = null!;
 
         private Hook<DutyReceiveEventDelegate>? addonDutyReceiveEventHook = null;
@@ -402,19 +396,9 @@ namespace WondrousTailsSolver
             return seString;
         }
 
-        private AgentInterface* GetAgentContentsFinder()
-        {
-            var framework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance();
-            var uiModule = framework->GetUiModule();
-            var agentModule = uiModule->GetAgentModule();
-            return agentModule->GetAgentByInternalId(AgentId.ContentsFinder);
-        }
-
         private void OpenRegularDuty(uint contentFinderCondition)
         {
-            var agent = this.GetAgentContentsFinder();
-            PluginLog.Debug($"OpenRegularDuty 0x{(IntPtr)agent:X} #{contentFinderCondition}");
-            this.openRegularDuty(agent, contentFinderCondition, 0);
+            AgentContentsFinder.Instance()->OpenRegularDuty(contentFinderCondition);
         }
 
         // Color format is RGBA

--- a/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
+++ b/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
@@ -177,62 +177,16 @@ namespace WondrousTailsSolver
                     return;
 
                 var duty = (DutySlot*)dutyPtr;
-                var status = this.wondrousTailsData->TaskStatus(duty->index);
-                if (status == ButtonState.Completable)
-                {
-                    var orderDataID = this.wondrousTailsData->Tasks[duty->index];
-                    var orderDataSheet = Service.DataManager.GetExcelSheet<Sheets.WeeklyBingoOrderData>()!;
-                    var orderDataRow = orderDataSheet.GetRow(orderDataID)!;
+                var dutiesForTask = TaskLookup.GetInstanceListFromID(wondrousTailsData->Tasks[duty->index]);
 
-                    var contentID = orderDataRow.Data;
-                    if (contentID < 1000)
-                    {
-                        uint cfcID = orderDataID switch
-                        {
-                            // CFC => WBO
-                            001 => 004, // Dungeons (Lv. 1-49)  => Sastasha
-                            002 => 010, // Dungeons (Lv. 50)    => Wanderer's Palace
-                            003 => 036, // Dungeons (Lv. 51-59) => Dusk Vigil
-                            004 => 038, // Dungeons (Lv. 60)    => Aetherochemical Research Facility
-                            059 => 238, // Dungeons (Lv. 61-69) => Sirensong Sea
-                            060 => 247, // Dungeons (Lv. 70)    => Ala Mhigo
-                            085 => 676, // Dungeons (Lv. 71-79) => Holminster Switch
-                            086 => 652, // Dungeons (Lv. 80)    => Amaurot
-                            108 => 783, // Dungeons (Lv. 81-89) => Tower of Zot
-                            109 => 792, // Dungeons (Lv. 90)    => Dead Ends
-                            046 => 000, // Maps
-                            053 => 000, // PotD/HoH
-                            052 => 862, // Crystalline Conflict => Crystalline Conflict (Custom Match - The Palaistra)
-                            054 => 127, // Frontline            => Frontline: Borderland Ruins
-                            067 => 277, // Rival Wings          => Rival Wings: Astralagos
-                            121 => 093, // Binding Coil of Bahamut
-                            122 => 098, // Second Coil of Bahamut
-                            123 => 107, // Final Coil of Bahamut
-                            124 => 112, // Alexander: Gordias
-                            125 => 136, // Alexander: Midas
-                            126 => 186, // Alexander: The Creator
-                            127 => 252, // Omega: Deltascape
-                            128 => 286, // Omega: Sigmascape
-                            129 => 587, // Omega: Alphascape
-                            _ => 0,
-                        };
+                var territoryType = dutiesForTask.FirstOrDefault();
+                var cfc = Service.DataManager.GetExcelSheet<Sheets.ContentFinderCondition>()!
+                    .FirstOrDefault(cfc => cfc.TerritoryType.Row == territoryType);
 
-                        if (cfcID == 0)
-                            return;
+                if (cfc == null)
+                    return;
 
-                        this.OpenRegularDuty(cfcID);
-                    }
-                    else
-                    {
-                        var cfcSheet = Service.DataManager.GetExcelSheet<Sheets.ContentFinderCondition>()!;
-                        var contents = cfcSheet.FirstOrDefault(row => row.Content == contentID);
-                        if (contents == default)
-                            return;
-
-                        var cfcID = contents.RowId;
-                        this.OpenRegularDuty(cfcID);
-                    }
-                }
+                this.OpenRegularDuty(cfc.RowId);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Rebuilt the task lookup to automatically get the new raid duties properly.
Also improved logic to use linq more intelligently reducing codebloat

Removed OpenContentFinder sigs, uses ClientStructs AgentContentsFinder instead

This PR does not increase the version number.