### PR TITLE
Fix Regression

### DIFF
--- a/WondrousTailsSolver/Service.cs
+++ b/WondrousTailsSolver/Service.cs
@@ -1,6 +1,7 @@
 using Dalamud.Data;
 using Dalamud.Game;
 using Dalamud.Game.ClientState;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 
@@ -34,5 +35,11 @@ namespace WondrousTailsSolver
         /// </summary>
         [PluginService]
         internal static ClientState ClientState { get; private set; } = null!;
+
+        /// <summary>
+        /// Gets the Dalamud Condition class.
+        /// </summary>
+        [PluginService]
+        internal static Condition Condition { get; private set; } = null!;
     }
 }

--- a/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
+++ b/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
@@ -177,16 +177,20 @@ namespace WondrousTailsSolver
                     return;
 
                 var duty = (DutySlot*)dutyPtr;
-                var dutiesForTask = TaskLookup.GetInstanceListFromID(wondrousTailsData->Tasks[duty->index]);
+                var status = this.wondrousTailsData->TaskStatus(duty->index);
+                if (status is ButtonState.Completable)
+                {
+                    var dutiesForTask = TaskLookup.GetInstanceListFromID(wondrousTailsData->Tasks[duty->index]);
 
-                var territoryType = dutiesForTask.FirstOrDefault();
-                var cfc = Service.DataManager.GetExcelSheet<Sheets.ContentFinderCondition>()!
-                    .FirstOrDefault(cfc => cfc.TerritoryType.Row == territoryType);
+                    var territoryType = dutiesForTask.FirstOrDefault();
+                    var cfc = Service.DataManager.GetExcelSheet<Sheets.ContentFinderCondition>()!
+                        .FirstOrDefault(cfc => cfc.TerritoryType.Row == territoryType);
 
-                if (cfc == null)
-                    return;
+                    if (cfc == null)
+                        return;
 
-                this.OpenRegularDuty(cfc.RowId);
+                    this.OpenRegularDuty(cfc.RowId);
+                }
             }
             catch (Exception ex)
             {

--- a/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
+++ b/WondrousTailsSolver/WondrousTailsSolverPlugin.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Text;
-
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
@@ -173,6 +173,9 @@ namespace WondrousTailsSolver
 
             try
             {
+                // Checks if the player is in a duty, excluding IslandSanctuary
+                if (IsBoundByDuty()) return;
+
                 if (this.wondrousTailsData == null)
                     return;
 
@@ -357,6 +360,24 @@ namespace WondrousTailsSolver
         private void OpenRegularDuty(uint contentFinderCondition)
         {
             AgentContentsFinder.Instance()->OpenRegularDuty(contentFinderCondition);
+        }
+
+        public static bool IsBoundByDuty()
+        {
+            if (IsInIslandSanctuary()) return false;
+
+            return Service.Condition[ConditionFlag.BoundByDuty] ||
+                   Service.Condition[ConditionFlag.BoundByDuty56] ||
+                   Service.Condition[ConditionFlag.BoundByDuty95];
+        }
+
+        public static bool IsInIslandSanctuary()
+        {
+            var territoryInfo = Service.DataManager.GetExcelSheet<Sheets.TerritoryType>()!.GetRow(Service.ClientState.TerritoryType);
+            if (territoryInfo is null) return false;
+
+            // Island Sanctuary
+            return territoryInfo.TerritoryIntendedUse == 49;
         }
 
         // Color format is RGBA


### PR DESCRIPTION
So sorry! When I was removing the hardcoded table, I accidentally removed the `completable` check.

This PR fixes the duty finder appearing when trying to reroll a task.

I also added a check to prevent it from trying to open the duty finder while in a duty.
This check excludes Island Sanctuary, as that should not be considered a duty.